### PR TITLE
Compatibility with the new SSA convention

### DIFF
--- a/src/drivers/linker.py
+++ b/src/drivers/linker.py
@@ -603,7 +603,15 @@ data_section = '''. = ALIGN(2);
     {1}
     . += {2};
     __sm_{0}_stack_init = .;
+    . += 2;
+    __sm_{0}_ssa_end = .;
+    . += 26;
     __sm_{0}_sp = .;
+    . += 2;
+    __sm_{0}_ssa_base = .;
+    __sm_{0}_pc = .;
+    . += 2;
+    __sm_{0}_ssa_thread_id = .;
     . += 2;
     __sm_{0}_irq_sp = .;
     . += 2;
@@ -612,8 +620,8 @@ data_section = '''. = ALIGN(2);
     . = ALIGN(2);
     {3}
     {4}
-    __sm_{0}_sp_addr = .;          /* make sure this is the last address in data
-                                  section, as HW IRQ logic will store SP here */
+    __sm_{0}_ssa_base_addr = .;          /* make sure this is the last address in data
+                                  section, as HW IRQ logic will look for SSA base pointer here */
     . += 2;
     . = ALIGN(2);
     __sm_{0}_secret_end = .;'''
@@ -669,8 +677,11 @@ for sm in sms:
                '__sm_isr_func'   : '__sm_{}_isr_func'.format(sm),
                '__sm_nentries'   : nentries,
                '__sm_table'      : '__sm_{}_table'.format(sm),
-               '__sm_sp_addr'    : '__sm_{}_sp_addr'.format(sm),
+               '__sm_ssa_base_addr'    : '__sm_{}_ssa_base_addr'.format(sm),
+               '__sm_ssa_base'    : '__sm_{}_ssa_base'.format(sm),
+               '__sm_ssa_end'    : '__sm_{}_ssa_end'.format(sm),
                '__sm_sp'         : '__sm_{}_sp'.format(sm),
+               '__sm_pc'         : '__sm_{}_pc'.format(sm),
                '__sm_irq_sp'     : '__sm_{}_irq_sp'.format(sm),
                '__sm_tmp'        : '__sm_{}_tmp'.format(sm),
                '__ret_entry'     : '__sm_{}_ret_entry'.format(sm),

--- a/src/stubs/sm_entry.s
+++ b/src/stubs/sm_entry.s
@@ -14,9 +14,19 @@ __sm_entry:
     ; not actually be called by an IRQ in which case we might overwrite a stored
     ; stack pointer.
     mov r1, &__sm_tmp
-    # Switch stack.
-    ; __sm_sp is our stackpointer
-    mov #__sm_sp, &__sm_sp_addr
+
+    ; initialize SSA on first entry (if ssa_thread_id is 0x0)
+    ; Use r1 for this check as we just backed it up
+    mov #__sm_ssa_base_addr, r1
+    cmp #0x0, r1
+    jne 1f
+    ; If SSA address was not initialized, do it now
+    ; Technically, this could be set to any SSA but we have just one for now
+    mov #__sm_ssa_base, &__sm_ssa_base_addr
+    
+1:  
+    ; Now switch the stack to the ssa base
+    ; __sm_sp is our stackpointer, it lies at #ssa_base-2
     mov &__sm_sp, r1
     ; initialize sp on first entry
     cmp #0x0, r1

--- a/src/stubs/sm_exit.s
+++ b/src/stubs/sm_exit.s
@@ -44,6 +44,8 @@ __sm_exit:
     .global __reti_entry
     .type __reti_entry,@function
 __reti_entry:
+    ; Pop registers backwards from SSA end -> SSA base
+    mov #__sm_ssa_base-28, r1
     pop r4
     pop r5
     pop r6
@@ -56,11 +58,14 @@ __reti_entry:
     pop r13
     pop r14
     pop r15
+    pop r2
 
-    ; clear sp
+    ; restore sp and clear memory pointer
+    mov &__sm_sp, r1
     mov #0, &__sm_sp
 
-    reti
+    ; branch to pc (r2 already restored manually above)
+    br &__sm_pc
 
     .align 2
     .global __ret_entry


### PR DESCRIPTION
These are small changes in the linker and the sm_entry and sm_exit stubs to make the linker compatible with the upcoming SSA changes (see https://github.com/sancus-tee/sancus-core/pull/24 )

The linker contains SSA labels for:
- ssa_base which is also ssa_pc
- ssa_sp which is at ssa_base-2
- ssa_end which is at ssa_base-28

Additionally, the linker also has a ssa_thread_id which lies above the SSA at ssa_base+2 for later compatibility when adding actual threading to the SSAs. This can be removed if you find it unclean to add this now.

Also, since we technically only need ssa_base from now on, we could refactor all stubs to recalculate the SP or PC etc from ssa_base on instead of keeping the ssa_sp and ssa_pc labels. But I am not sure whether sm_pc is needed elsewhere so I refrained from renaming it.