### PR TITLE
Add `sancus_untag` functions and fix `sancus_unwrap_with_key`

### DIFF
--- a/src/sancus_support/sm_support.h
+++ b/src/sancus_support/sm_support.h
@@ -537,7 +537,7 @@ always_inline int sancus_untag_with_key(const void* key, const void* body,
     }
 
     // compare MAC with provided reference `tag`
-    return constant_time_cmp(tag, computed_tag, SANCUS_TAG_SIZE);
+    return (constant_time_cmp(tag, computed_tag, SANCUS_TAG_SIZE) == 0);
 }
 
 /**


### PR DESCRIPTION
This implements what discussed in #36 and fixes (in sw of course) the bug mentioned in sancus-tee/sancus-core#26.

About the constant-time comparison function, I basically copied the NaCl function referenced in #31. However, I didn't really understand why they use this logic in the return statement:
```c
return (1 & ((d - 1) >> 8)) - 1;
```
Is there a specific reason for this logic (I mean, in terms of security)? Can't this be simplified to something like `return d == 0`?

I also had to move `sancus_tag` and `sancus_tag_with_key` up in the file. The reason is because I added a call to `sancus_untag_with_key` inside `sancus_unwrap_with_key`, therefore the former needed to be declared before the latter.

Edit: I just read what @jovanbulck wrote in #31, so that logic in the `return` statement is to avoid having an if branch. Good!