### PR TITLE
Remove sm_sp from isr stub

### DIFF
--- a/src/stubs/sm_isr.s
+++ b/src/stubs/sm_isr.s
@@ -42,6 +42,5 @@ __sm_isr:
     pop r15
 
     ; Switch the stack.
-    mov r1, &__sm_sp
     mov &__sm_irq_sp, r1
     reti


### PR DESCRIPTION
This removes the usage of __sm_sp from the isr stub. We now use the existence of sm_sp as a marker that a return from an OCALL is expected which means that it should not be set on leaving an ISR. See also #38 