### PR TITLE
Compilation error in constant_time_cmp

### DIFF
--- a/src/sancus_support/sm_support.h
+++ b/src/sancus_support/sm_support.h
@@ -354,7 +354,7 @@ always_inline int constant_time_cmp(const unsigned char *x_,
     const volatile unsigned char *volatile y =
         (const volatile unsigned char *volatile) y_;
     volatile unsigned int d = 0U;
-    int i;
+    unsigned int i;
 
     for (i = 0; i < n; i++) {
         d |= x[i] ^ y[i];


### PR DESCRIPTION
Changed counter "i" to be an unsigned int. This resolves the compiler errors about comparing "int" and "unsigned int" types.
When running inside the docker the compiler did not throw any error, but if running just on Linux without the Docker, then the following error was thrown:
![image](https://user-images.githubusercontent.com/43750927/139823981-bd9fd90f-1c9e-4f03-9d9a-4b1349b36c9f.png)

